### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
-    @items = Item.all.order('created_at DESC')
+    @items = Item.order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,10 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
+  def index
+    @items = Item.all.order('created_at DESC')
+  end
+
   def new
     @item = Item.new
   end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -12,4 +12,7 @@ class Category < ActiveHash::Base
     { id: 10, name: 'ハンドメイド' },
     { id: 11, name: 'その他' }
   ]
+
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -4,4 +4,6 @@ class Charge < ActiveHash::Base
     { id: 2, name: '着払い(購入者負担)' },
     { id: 3, name: '送料込み(出品者負担)' }
   ]
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -8,4 +8,7 @@ class Condition < ActiveHash::Base
     { id: 6, name: '傷や汚れあり' },
     { id: 7, name: '全体的に状態が悪い' }
   ]
+
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/models/delivery_time.rb
+++ b/app/models/delivery_time.rb
@@ -5,4 +5,6 @@ class DeliveryTime < ActiveHash::Base
     { id: 3, name: '2~3日で発送' },
     { id: 4, name: '4~7日で発送' }
   ]
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -22,4 +22,12 @@ class Item < ApplicationRecord
 
   belongs_to :user
   has_one_attached :image
+
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :category
+  belongs_to_active_hash :condition
+  belongs_to_active_hash :charge
+  belongs_to_active_hash :ship_from_area
+  belongs_to_active_hash :delivery_time
+
 end

--- a/app/models/ship_from_area.rb
+++ b/app/models/ship_from_area.rb
@@ -49,4 +49,7 @@ class ShipFromArea < ActiveHash::Base
     { id: 47, name: '鹿児島県' },
     { id: 48, name: '沖縄県' }
   ]
+
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,59 +123,57 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+      <% if @items.present? %>
+        <% @items.each do |item| %>
+          <li class='list'>
+            <%= link_to "#" do %>
+            <div class='item-img-content'>
+              <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+              <%# 商品が売れていればsold outを表示しましょう %>
+              <div class='sold-out'>
+                <span><!-Sold Out!!-></span>
+              </div->
+              <%# //商品が売れていればsold outを表示しましょう %>
 
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+            </div>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.name %>
+              </h3>
+              <div class='item-price'>
+                <span><%= item.price %>円<br><%= item.charge.name %></span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
+            <% end %>
+          </li>
+        <% end %>
+      <% else %>
+        <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+          <% end %>
+        </li>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
 
-  resources :items, only: [:new, :create]
+  resources :items, only: [:new, :create, :index]
 
 end


### PR DESCRIPTION
# what
商品一覧表示機能実装

# why
商品一覧を表示するため

# 画像
- [商品一覧表示](https://gyazo.com/4b285a151f36dd683051df08404d11e6)
- 出品日時が新しい順 [一覧表示](https://gyazo.com/b7a001290a43d10a8b76108e3bd83ba8)  [sequel pro](https://gyazo.com/f78a1a06e94cabcc924e93fca410b712)
- [ログアウト中ユーザーも一覧表示を見ることができる](https://gyazo.com/16ad2fff13946b99f03cebb8bb4e3362)

※「soldout」表示は未実装